### PR TITLE
Follow tzinfo updates

### DIFF
--- a/lib/tzinfo/virtual_timezone.rb
+++ b/lib/tzinfo/virtual_timezone.rb
@@ -6,14 +6,18 @@ module TZInfo
       vt
     end
 
+    def period_for(_time)
+      TimezonePeriod.new(@offset)
+    end
+
     # Returns the TimezonePeriod based on the given seconds from GMT.
     def period_for_utc(_utc)
-      TimezonePeriod.new(nil, nil, @offset)
+      TimezonePeriod.new(@offset)
     end
 
     # Returns the array of TimezonePeriod based on the given seconds from GMT.
     def periods_for_local(_local)
-      [TimezonePeriod.new(nil, nil, @offset)]
+      [TimezonePeriod.new(@offset)]
     end
 
     def identifier
@@ -24,7 +28,7 @@ module TZInfo
 
       def setup(seconds_from_gmt)
         @seconds_from_gmt = seconds_from_gmt
-        @offset = TimezoneOffset.new(@seconds_from_gmt, 0, :VirtualTimeZone)
+        @offset = TimezoneOffset.new(@seconds_from_gmt, 0, 'VirtualTimeZone')
       end
   end
 end

--- a/lib/tzinfo/virtual_timezone.rb
+++ b/lib/tzinfo/virtual_timezone.rb
@@ -7,17 +7,17 @@ module TZInfo
     end
 
     def period_for(_time)
-      TimezonePeriod.new(@offset)
+      OffsetTimezonePeriod.new(@offset)
     end
 
     # Returns the TimezonePeriod based on the given seconds from GMT.
     def period_for_utc(_utc)
-      TimezonePeriod.new(@offset)
+      OffsetTimezonePeriod.new(@offset)
     end
 
     # Returns the array of TimezonePeriod based on the given seconds from GMT.
     def periods_for_local(_local)
-      [TimezonePeriod.new(@offset)]
+      [OffsetTimezonePeriod.new(@offset)]
     end
 
     def identifier

--- a/test/real_time_zone_rails_test.rb
+++ b/test/real_time_zone_rails_test.rb
@@ -20,7 +20,7 @@ class RealTimeZoneRailsTest < ActiveSupport::TestCase
 
   def test_period_for_local
     zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
-    assert_instance_of TZInfo::TimezonePeriod, zone.period_for_local(Time.utc(2000))
+    assert_instance_of TZInfo::TransitionsTimezonePeriod, zone.period_for_local(Time.utc(2000))
   end
 
   ActiveSupport::TimeZone::MAPPING.each_key do |name|

--- a/test/virtual_time_zone_rails_test.rb
+++ b/test/virtual_time_zone_rails_test.rb
@@ -16,7 +16,7 @@ class VirtualTimeZoneRailsTest < ActiveSupport::TestCase
 
   def test_period_for_local
     zone = ActiveSupport::TimeZone[-18000]
-    assert_instance_of TZInfo::TimezonePeriod, zone.period_for_local(Time.utc(2000))
+    assert_instance_of TZInfo::OffsetTimezonePeriod, zone.period_for_local(Time.utc(2000))
   end
 
   def test_now

--- a/virtual_time_zone_rails.gemspec
+++ b/virtual_time_zone_rails.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport", ">= 5.0"
-  spec.add_dependency "tzinfo", ">= 1.1"
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_dependency "tzinfo", ">= 2.0"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "minitest", "~>5.1"
 end


### PR DESCRIPTION
## 概要

tzinfoのメジャーアップデートに追従させました

## 経緯

rails 6.1 から `tzinfo ~> 2.0`が指定されるようになったので、最新のrailsでこのgemを使えるようにするためにtzinfoのバージョン指定をあげ、それに合わせて処理も修正しました

## 修正の詳細

- bundlerのバージョン指定を`~> 2.0`に更新しました
- tzinfoのバージョン指定を `>= 2.0`に変更しました
- ~`TimezonePeriod`が`TimezonePeriod`と`TransitionsTimezonePeriod`に分割された変更に対応しました~
- `TimezonePeriod`が`OffsetTimezonePeriod`と`TransitionsTimezonePeriod`に分割された変更に対応しました